### PR TITLE
fix(release): デプロイ用と開発用のcomposeファイルに分割

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,4 +36,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ inputs.tag-name }} compose.yml --clobber
+          gh release upload ${{ inputs.tag-name }} ./deployment/compose.yml --clobber

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -1,8 +1,6 @@
 services:
   app:
-    build: 
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/approvers/yomiage-mon:latest
     env_file:
       - .env
     init: true


### PR DESCRIPTION
開発時にデプロイサれているイメージを引っ張ってしまうとデバッグやテスト運用がし辛いので別個追加するファイルを分けるようにしました｡